### PR TITLE
Add allowShades property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.05
+
+* Add `allowShades` property
+
 ## 0.0.4
 
 * Fix icon on selected color

--- a/README.md
+++ b/README.md
@@ -50,6 +50,21 @@ MaterialColorPicker(
 )
 ```
 
+### Disallow Shades
+
+```dart
+MaterialColorPicker(
+    allowShades: false, // default true
+    onMainColorChange: (ColorSwatch color) {
+        // Handle main color changes
+    },
+    selectedColor: Colors.red
+)
+```
+If `allowShades` is set to `false` then only main colors will be shown and allowed to be selected.
+`onColorChange` will not be called, use `onMainColorChange` instead.
+
+
 ### Custom colors
 
 In this example, custom colors are a list of Material Colors (class who extend of ColorSwatch).

--- a/lib/src/material_color_picker.dart
+++ b/lib/src/material_color_picker.dart
@@ -94,7 +94,6 @@ class _MaterialColorPickerState extends State<MaterialColorPicker> {
       _isMainSelection = false;
     });
     if (widget.onMainColorChange != null) widget.onMainColorChange(color);
-    if (widget.onColorChange != null) widget.onColorChange(shadeColor);
   }
 
   void _onShadeColorSelected(Color color) {

--- a/lib/src/material_color_picker.dart
+++ b/lib/src/material_color_picker.dart
@@ -10,6 +10,7 @@ class MaterialColorPicker extends StatefulWidget {
   final ValueChanged<Color> onColorChange;
   final ValueChanged<ColorSwatch> onMainColorChange;
   final List<ColorSwatch> colors;
+  final bool allowShades;
   final double circleSize;
   final IconData iconSelected;
 
@@ -19,6 +20,7 @@ class MaterialColorPicker extends StatefulWidget {
       this.onColorChange,
       this.onMainColorChange,
       this.colors,
+      this.allowShades = true,
       this.iconSelected = _kIconSelected,
       this.circleSize = _kCircleColorSize})
       : super(key: key);
@@ -94,6 +96,7 @@ class _MaterialColorPickerState extends State<MaterialColorPicker> {
       _isMainSelection = false;
     });
     if (widget.onMainColorChange != null) widget.onMainColorChange(color);
+    if (widget.allowShades && widget.onColorChange != null) widget.onColorchange(color);
   }
 
   void _onShadeColorSelected(Color color) {
@@ -169,7 +172,7 @@ class _MaterialColorPickerState extends State<MaterialColorPicker> {
 
   @override
   Widget build(BuildContext context) {
-    final listChildren = _isMainSelection
+    final listChildren = _isMainSelection || !widget.allowShades
         ? _buildListMainColor(_colors)
         : _buildListShadesColor(_mainColor);
 

--- a/lib/src/material_color_picker.dart
+++ b/lib/src/material_color_picker.dart
@@ -96,7 +96,7 @@ class _MaterialColorPickerState extends State<MaterialColorPicker> {
       _isMainSelection = false;
     });
     if (widget.onMainColorChange != null) widget.onMainColorChange(color);
-    if (widget.allowShades && widget.onColorChange != null) widget.onColorchange(shadeColor);
+    if (widget.allowShades && widget.onColorChange != null) widget.onColorChange(shadeColor);
   }
 
   void _onShadeColorSelected(Color color) {

--- a/lib/src/material_color_picker.dart
+++ b/lib/src/material_color_picker.dart
@@ -96,7 +96,7 @@ class _MaterialColorPickerState extends State<MaterialColorPicker> {
       _isMainSelection = false;
     });
     if (widget.onMainColorChange != null) widget.onMainColorChange(color);
-    if (widget.allowShades && widget.onColorChange != null) widget.onColorchange(color);
+    if (widget.allowShades && widget.onColorChange != null) widget.onColorchange(shadeColor);
   }
 
   void _onShadeColorSelected(Color color) {


### PR DESCRIPTION
This allows the user to choose if they want shades to be allowed at all. Defaults to true.
Also controls the `onColorChange` callback, which can't be used in conjunction with `allowShades: false`. Users would use only `onMainColorChange` instead.

I can update the docs and change list if you accept this PR.