### PR TITLE
onlyShadeSelection option

### DIFF
--- a/lib/src/material_color_picker.dart
+++ b/lib/src/material_color_picker.dart
@@ -11,6 +11,7 @@ class MaterialColorPicker extends StatefulWidget {
   final ValueChanged<ColorSwatch> onMainColorChange;
   final List<ColorSwatch> colors;
   final bool allowShades;
+  final bool onlyShadeSelection;
   final double circleSize;
   final IconData iconSelected;
 
@@ -21,6 +22,7 @@ class MaterialColorPicker extends StatefulWidget {
     this.onMainColorChange,
     this.colors,
     this.allowShades = true,
+    this.onlyShadeSelection = false,
     this.iconSelected = _kIconSelected,
     this.circleSize = _kCircleColorSize,
   }) : super(key: key);
@@ -98,6 +100,9 @@ class _MaterialColorPickerState extends State<MaterialColorPicker> {
       _isMainSelection = false;
     });
     if (widget.onMainColorChange != null) widget.onMainColorChange(color);
+    if (widget.onlyShadeSelection && !_isMainSelection) {
+      return;
+    }
     if (widget.allowShades && widget.onColorChange != null)
       widget.onColorChange(shadeColor);
   }


### PR DESCRIPTION
When the onlyShadeSelection option is set to true it will only emit changes coming from the shade selection.

This is nessecary when changing the selectedColor of the colorpicker depending on what it emits. Without the change the mainColor would be selected, emitted through onColorChange and onMainColorChange. The colors couldn't be differentiated and had to be set, thus skipping / ignoring the shade selection that also offers the main color.

Might be wise to make it the default for onColorChange and keep emitting changes of MainColor to onMainColorChange