### PR TITLE
Fix issue with media query and circle size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.2.0
+
+* **Can be a break change:** Change to use a `Wrap` rather than a `GridView` ([See this PR](https://github.com/Pyozer/flutter_material_color_picker/pull/30))
+
 ## 1.1.0+2
 
 * Minor null safety improvements ([See this PR](https://github.com/Pyozer/flutter_material_color_picker/pull/27))

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -35,8 +35,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "fr.pyozer.example"
-        minSdkVersion 16
-        targetSdkVersion 30
+        minSdkVersion 21
+        targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:exported="true">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -24,6 +24,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -30,7 +30,7 @@ class _HomeScreenState extends State<HomeScreen> {
       context: context,
       builder: (_) {
         return AlertDialog(
-          contentPadding: const EdgeInsets.all(6.0),
+          contentPadding: const EdgeInsets.all(18.0),
           title: Text(title),
           content: content,
           actions: [
@@ -102,52 +102,54 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Text(
-            "Material color picker",
-            style: Theme.of(context).textTheme.headline5,
-          ),
-          const SizedBox(height: 62.0),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              CircleAvatar(
-                backgroundColor: _mainColor,
-                radius: 35.0,
-                child: const Text("MAIN"),
-              ),
-              const SizedBox(width: 16.0),
-              CircleAvatar(
-                backgroundColor: _shadeColor,
-                radius: 35.0,
-                child: const Text("SHADE"),
-              ),
-            ],
-          ),
-          const SizedBox(height: 32.0),
-          OutlinedButton(
-            onPressed: _openColorPicker,
-            child: const Text('Show color picker'),
-          ),
-          const SizedBox(height: 16.0),
-          OutlinedButton(
-            onPressed: _openMainColorPicker,
-            child: const Text('Show main color picker'),
-          ),
-          const Text('(only main color)'),
-          const SizedBox(height: 16.0),
-          OutlinedButton(
-            onPressed: _openAccentColorPicker,
-            child: const Text('Show accent color picker'),
-          ),
-          const SizedBox(height: 16.0),
-          OutlinedButton(
-            onPressed: _openFullMaterialColorPicker,
-            child: const Text('Show full material color picker'),
-          ),
-        ],
+      body: SingleChildScrollView(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              "Material color picker",
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 62.0),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                CircleAvatar(
+                  backgroundColor: _mainColor,
+                  radius: 35.0,
+                  child: const Text("MAIN"),
+                ),
+                const SizedBox(width: 16.0),
+                CircleAvatar(
+                  backgroundColor: _shadeColor,
+                  radius: 35.0,
+                  child: const Text("SHADE"),
+                ),
+              ],
+            ),
+            const SizedBox(height: 32.0),
+            OutlinedButton(
+              onPressed: _openColorPicker,
+              child: const Text('Show color picker'),
+            ),
+            const SizedBox(height: 16.0),
+            OutlinedButton(
+              onPressed: _openMainColorPicker,
+              child: const Text('Show main color picker'),
+            ),
+            const Text('(only main color)'),
+            const SizedBox(height: 16.0),
+            OutlinedButton(
+              onPressed: _openAccentColorPicker,
+              child: const Text('Show accent color picker'),
+            ),
+            const SizedBox(height: 16.0),
+            OutlinedButton(
+              onPressed: _openFullMaterialColorPicker,
+              child: const Text('Show full material color picker'),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -36,7 +36,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.0+2"
+    version: "1.2.0"
   js:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,21 +5,24 @@ packages:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.3.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.17.1"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      url: "https://pub.dartlang.org"
+      sha256: "486b7bc707424572cdf7bd7e812a0c146de3fd47ecadf070254cc60383f21dd8"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
   flutter:
@@ -34,32 +37,43 @@ packages:
       relative: true
     source: path
     version: "1.1.0+2"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.7"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.9.1"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.99"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.4"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=1.17.0"

--- a/lib/src/material_color_picker.dart
+++ b/lib/src/material_color_picker.dart
@@ -7,6 +7,7 @@ class MaterialColorPicker extends StatefulWidget {
   final ValueChanged<Color>? onColorChange;
   final ValueChanged<ColorSwatch?>? onMainColorChange;
   final List<ColorSwatch>? colors;
+  @Deprecated('No longer used')
   final bool shrinkWrap;
   final ScrollPhysics? physics;
   final bool allowShades;
@@ -16,6 +17,9 @@ class MaterialColorPicker extends StatefulWidget {
   final IconData iconSelected;
   final VoidCallback? onBack;
   final double? elevation;
+  final WrapAlignment alignment;
+  final WrapAlignment runAlignment;
+  final WrapCrossAlignment crossAxisAlignment;
 
   const MaterialColorPicker({
     Key? key,
@@ -32,6 +36,9 @@ class MaterialColorPicker extends StatefulWidget {
     this.spacing = 9.0,
     this.onBack,
     this.elevation,
+    this.alignment = WrapAlignment.start,
+    this.runAlignment = WrapAlignment.center,
+    this.crossAxisAlignment = WrapCrossAlignment.center,
   }) : super(key: key);
 
   @override
@@ -176,20 +183,14 @@ class _MaterialColorPickerState extends State<MaterialColorPicker> {
         ? _buildListMainColor(_colors)
         : _buildListShadesColor(_mainColor);
 
-    // Size of dialog
-    final double width = MediaQuery.of(context).size.width * 0.8;
-    // Number of circle per line, depend on width and circleSize
-    final int nbrCircleLine = width ~/ (widget.circleSize + widget.spacing);
-
-    return Container(
-      width: width,
-      child: GridView.count(
-        shrinkWrap: widget.shrinkWrap,
-        physics: widget.physics,
-        padding: const EdgeInsets.all(16.0),
-        crossAxisSpacing: widget.spacing,
-        mainAxisSpacing: widget.spacing,
-        crossAxisCount: nbrCircleLine,
+    return SingleChildScrollView(
+      physics: widget.physics,
+      child: Wrap(
+        alignment: widget.alignment,
+        runAlignment: widget.runAlignment,
+        crossAxisAlignment: widget.crossAxisAlignment,
+        runSpacing: widget.spacing,
+        spacing: widget.spacing,
         children: listChildren,
       ),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,47 +5,60 @@ packages:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.3.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.17.1"
   flutter:
     dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.7"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.9.1"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.99"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.4"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=1.17.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_material_color_picker
 description: Material color picker with some possible customizations for Flutter apps
-version: 1.1.0+2
+version: 1.2.0
 homepage: https://github.com/Pyozer/flutter_material_color_picker
 
 environment:


### PR DESCRIPTION
This change fixes an issue with the circle size as it was based on the width of the device. The larger the width, the smaller the rendered circle size. This issue is demonstrated in the attached video. But you could also see the same problem with the example when rotating between portrait and landscape.

https://github.com/Pyozer/flutter_material_color_picker/assets/1913052/8b1659f5-bbc9-4028-a3d5-b4244139c99a


Main change was to use a Wrap, rather than a GridView as this ensures a consistent circle size.

Other changes were made to enable the example to run.

Video showing the fix:

https://github.com/Pyozer/flutter_material_color_picker/assets/1913052/19c74f77-7663-45d9-9ce5-b9519111b1af


